### PR TITLE
Use Base version of ispositive/isnegative on 1.13

### DIFF
--- a/src/Utilities.jl/src/Utilities.jl
+++ b/src/Utilities.jl/src/Utilities.jl
@@ -99,12 +99,20 @@ function two(::I) where {I}
     return two(I)
 end
 
-function ispositive(i::I) where {I}
-    return i > zero(I)
+@static if isdefined(Base, :ispositive)
+    import Base.ispositive
+else
+    function ispositive(i::I) where {I}
+        return i > zero(I)
+    end
 end
 
-function isnegative(i::I) where {I}
-    return i < zero(I)
+@static if isdefined(Base, :isnegative)
+    import Base.isnegative
+else
+    function isnegative(i::I) where {I}
+        return i < zero(I)
+    end
 end
 
 function isfour(i::I) where {I}


### PR DESCRIPTION
The base version is only defined for `::Real` but it seems that it should work for the usecases here.