### PR TITLE
Use joinpath instead of UNIX "/"

### DIFF
--- a/ext/FlowCutterPACE17_jllExt.jl
+++ b/ext/FlowCutterPACE17_jllExt.jl
@@ -15,8 +15,8 @@ function flowcutter(graph::AbstractGraph{V}, time::Int, seed::Int) where {V}
     @assert seed >= 0
 
     index = mktempdir() do tmp
-        input = joinpath(tmp, "/input.gr")
-        output = joinpath(tmp, "/output.td")
+        input = joinpath(tmp, "input.gr")
+        output = joinpath(tmp, "output.td")
 
         open(input; write = true) do io
             writegr(io, graph)

--- a/ext/FlowCutterPACE17_jllExt.jl
+++ b/ext/FlowCutterPACE17_jllExt.jl
@@ -15,8 +15,8 @@ function flowcutter(graph::AbstractGraph{V}, time::Int, seed::Int) where {V}
     @assert seed >= 0
 
     index = mktempdir() do tmp
-        input = tmp * "/input.gr"
-        output = tmp * "/output.td"
+        input = joinpath(tmp, "/input.gr")
+        output = joinpath(tmp, "/output.td")
 
         open(input; write = true) do io
             writegr(io, graph)


### PR DESCRIPTION
I noticed that on Windows systems, the FlowCutter tests throw a warning:
> Warning: FlowCutter failed: ErrorException("Empty File")

https://github.com/AlgebraicJulia/CliqueTrees.jl/actions/runs/23609755037/job/68762072394#step:7:646

In the FlowCutterPACE17_jll extension, file names were being created by doing string appending with "/". I swapped this out with the cross-platform `joinpath`.

I haven't run this locally yet, but we can check the Windows action to see if the error is still thrown.